### PR TITLE
Allow user to specify headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features:
 
 - filter requests by method (get/post/patch/delete) and/or regular expression
 - log requests into storage of your choice (at the moment redis supported)
+- choose what headers you want to store and transform them if you want to
 
 Work in progress.
 
@@ -60,6 +61,32 @@ Rack::RequestPolice.configure do |config|
   # array of methods that should be logged (all four by default)
   # requests not included in this list will be ignored
   config.method = [:get, :post, :delete, :patch]
+
+  # array of headers that you want to store for each request (empty by default)
+  config.headers = [
+    "HTTP_HEADER_NAME",
+    "HTTP_ANOTHER_HEADER_NAME"
+  ]
+
+  # each item in headers array can be also defined using helper method config.header
+  #
+  # @param original_header_name is required and it is a name of original header
+  #
+  # options:
+  # storage_name - name of under which http header will be stored, default - original_header_name
+  # fallback_value - value of header that will be logged if header is missing, default - nil
+  #
+  # @block - optional transformations of the header before it is stored
+  #
+  # Example:
+  # config.headers = [
+  #   config.header("HTTP_HEADER_NAME",
+  #     storage_name: 'HEADER_NAME',
+  #     fallback_value: 'HEADER_IS_MISSING'
+  #   ) { |header| header.downcase },
+  #   config.header("HTTP_ANOTHER_HEADER_NAME"),
+  #   config.header("HTTP_ANOTHER_FANCY_HEADER", storage_name: 'fancy_header')
+  # ]
 end
 ```
 

--- a/lib/rack/request_police.rb
+++ b/lib/rack/request_police.rb
@@ -12,6 +12,7 @@ module Rack
     @@storage = nil
     @@method  = [:get, :post, :delete, :patch]
     @@regex   = nil
+    @@headers = []
 
     def self.configure
       yield self
@@ -23,6 +24,34 @@ module Rack
 
     def self.storage
       @@storage || fail(NoStorageFound)
+    end
+
+    def self.headers
+      @@headers
+    end
+
+    def self.headers=(array)
+      @@headers = array.map do |h|
+        # because headers might be simple strings
+        # or a hash we need to normalize them
+        # and store all as hashes
+        if h.is_a?(String)
+          header(h)
+        else
+          h
+        end
+      end
+    end
+
+    def self.header(original_header_name, options = {}, &transformation)
+      {
+        original_header_name: original_header_name,
+        storage_name: options.fetch(:storage_name) { original_header_name },
+        fallback_value: options.fetch(:fallback_value) { nil },
+        # if user provided no transformation,
+        # simply return original header value
+        transformation: transformation || ->(h){ h }
+      }
     end
 
     def self.method

--- a/lib/rack/request_police/version.rb
+++ b/lib/rack/request_police/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module RequestPolice
-    VERSION = "0.0.4alpha"
+    VERSION = "0.1.0alpha"
   end
 end

--- a/spec/bench.rb
+++ b/spec/bench.rb
@@ -76,6 +76,43 @@ describe "Simple benchmark", type: :request do
     end
   end
 
+  context "with middleware (customized headers, redis storage)" do
+    let(:headers) {
+      {
+        "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+        "HTTP_X_FORWARDED_FOR" => "129.78.138.66, 129.78.64.103",
+        "HTTP_X_CSRF_TOKEN" => "i8XNjC4b8KVok4uw5RftR38Wgp2BFwql",
+        "HTTP_AUTHORIZATION" => "Bearer Ym9zY236Ym9zY28="
+      }
+    }
+
+    after  { REDIS.flushdb }
+    before do
+      REDIS.flushdb
+      Rack::RequestPolice.configure do |c|
+        c.storage = Rack::RequestPolice::Storage::Redis.new(REDIS_OPTIONS)
+        c.regex = /.*/
+        c.method = [:get, :post, :delete]
+        c.headers = [
+          "HTTP_X_REQUESTED_WITH",
+          "HTTP_X_CSRF_TOKEN",
+          c.header("HTTP_X_FORWARDER_FOR", storage_name: "x-forwarded-for") { |h| h.split(",").first },
+          c.header("HTTP_AUTHORIZATION", storage_name: 'authorization') { |h| h.gsub("Bearer ", "") }
+        ]
+      end
+    end
+
+    it "benchmarks it" do
+      puts "with middleware (customized headers, redis storage)"
+      Benchmark.bm(7) do |x|
+        x.report("get") { repeat.times { get '/', {}, headers } }
+        x.report("post") { repeat.times { post '/', {}, headers } }
+        x.report("delete") { repeat.times { delete '/', {}, headers } }
+        x.report("patch") { repeat.times { patch '/', {}, headers } }
+      end
+    end
+  end
+
   context "with middleware (customized, redis storage, OJ json parser)" do
     after  { REDIS.flushdb }
     before do


### PR DESCRIPTION
Fixes #1

Hello @emq ;)

Hope you find it useful

Just one thing, I don't know it is just me or it is simply broken

``` ruby
  1) My Middleware logging without storage raises an error
     Failure/Error: expect { get '/' }.to raise_error(Rack::RequestPolice::NoStorageFound)
       expected Rack::RequestPolice::NoStorageFound but nothing was raised
     # ./spec/middleware_spec.rb:222:in `block (3 levels) in <top (required)
```

I also had to  modify configuration in other specs, because class variables were cached between specs and test result were undetermistic.
